### PR TITLE
Standardize README: badges, Conda install, License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AcidPlyr
 
-[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/recipes/r-acidplyr/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
+[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/r-acidplyr/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
 
 A grammar of S4 class data manipulation.
 


### PR DESCRIPTION
- Fix Bioconda badge link: `http://` → `https://`